### PR TITLE
Add bill summarizer with multi-level summaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,24 @@
-# US-bill-comparison-engine
+# US Bill Comparison Engine
+
+This project provides tools for preprocessing and summarizing United States government bills. The `bill_preprocessor` module cleans raw legislative text and structures it into sections for further analysis.
+
+## Preprocessor Features
+
+- Remove headers, footers, and legal citations
+- Identify sections and amendments
+- Extract bill metadata
+- Handle PDF, HTML, and plain text inputs
+
+Run unit tests with:
+
+```bash
+pytest
+```
+
+## Summarizer Features
+
+- Multi-level summaries: executive, standard, and detailed
+- Extract key numbers and affected parties
+- Provide readability score using Flesch-Kincaid grade level
+
+

--- a/bill_preprocessor/__init__.py
+++ b/bill_preprocessor/__init__.py
@@ -1,0 +1,12 @@
+"""Bill preprocessor package."""
+
+from .models import BillDocument, BillMetadata, BillSection
+from .preprocessor import BillPreprocessor
+
+__all__ = [
+    "BillDocument",
+    "BillMetadata",
+    "BillSection",
+    "BillPreprocessor",
+]
+

--- a/bill_preprocessor/models.py
+++ b/bill_preprocessor/models.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List, Optional
+
+
+@dataclass
+class BillMetadata:
+    """Metadata extracted from a bill."""
+
+    bill_number: Optional[str] = None
+    title: Optional[str] = None
+    introduction_date: Optional[str] = None
+
+
+@dataclass
+class BillSection:
+    """A bill section with optional nested subsections."""
+
+    title: str
+    text: str
+    subsections: List[BillSection] = field(default_factory=list)
+
+
+@dataclass
+class BillDocument:
+    """Structured representation of a bill."""
+
+    metadata: BillMetadata
+    sections: List[BillSection]
+    amendments: List[BillSection] = field(default_factory=list)
+    references: List[str] = field(default_factory=list)

--- a/bill_preprocessor/preprocessor.py
+++ b/bill_preprocessor/preprocessor.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import List, Optional
+
+try:
+    import spacy
+except ImportError:  # pragma: no cover - spaCy may be unavailable in test env
+    spacy = None
+
+try:
+    from bs4 import BeautifulSoup
+except ImportError:  # pragma: no cover - BeautifulSoup may be unavailable
+    BeautifulSoup = None  # type: ignore
+
+try:
+    from pdfminer.high_level import extract_text as pdf_extract_text
+except ImportError:  # pragma: no cover - pdfminer may be unavailable
+    pdf_extract_text = None  # type: ignore
+
+if spacy is not None:
+    from spacy.language import Language
+else:  # pragma: no cover - spaCy not installed
+    Language = object  # type: ignore
+
+from .models import BillDocument, BillMetadata, BillSection
+
+
+class BillPreprocessor:
+    """Preprocess and structure bill text."""
+
+    HEADER_PATTERN = re.compile(r"^\s*(?:Page\s+\d+|\w+\s+Congress)\s*$", re.IGNORECASE)
+    SECTION_PATTERN = re.compile(r"^(section\s+\d+|sec\.\s*\d+)", re.IGNORECASE)
+    AMENDMENT_PATTERN = re.compile(r"^amendments?", re.IGNORECASE)
+    REFERENCES_PATTERN = re.compile(r"^references?", re.IGNORECASE)
+
+    def __init__(self, nlp: Optional[Language] = None) -> None:
+        if nlp is None:
+            if spacy is None:
+                self.nlp = None
+                return
+            try:
+                nlp = spacy.load("en_core_web_sm")
+            except Exception:
+                nlp = spacy.blank("en")
+        self.nlp = nlp
+
+    def load_text(self, path: str) -> str:
+        """Return text content depending on file type."""
+        ext = Path(path).suffix.lower()
+        if ext == ".pdf":
+            return self._extract_text_from_pdf(path)
+        text = Path(path).read_text(encoding="utf-8")
+        if ext in {".html", ".htm"}:
+            return self._extract_text_from_html(text)
+        return text
+
+    @staticmethod
+    def _extract_text_from_pdf(path: str) -> str:
+        if pdf_extract_text is None:
+            raise ImportError("pdfminer.six is required to read PDF files")
+        try:
+            return pdf_extract_text(path)
+        except Exception as exc:
+            raise ValueError(f"Could not read PDF: {path}") from exc
+
+    @staticmethod
+    def _extract_text_from_html(html: str) -> str:
+        if BeautifulSoup is None:
+            raise ImportError("BeautifulSoup is required to parse HTML")
+        soup = BeautifulSoup(html, "html.parser")
+        return soup.get_text(separator="\n")
+
+    def preprocess(self, text: str) -> BillDocument:
+        """Clean raw text and return a structured bill document."""
+        lines = [line for line in text.splitlines() if line.strip()]
+        cleaned_lines = [ln for ln in lines if not self.HEADER_PATTERN.match(ln)]
+        cleaned_text = "\n".join(cleaned_lines)
+
+        metadata = self._extract_metadata(cleaned_text)
+        sections = self._split_sections(cleaned_lines)
+        amendments = [s for s in sections if self.AMENDMENT_PATTERN.match(s.title)]
+        references = [s.text for s in sections if self.REFERENCES_PATTERN.match(s.title)]
+        main_sections = [s for s in sections if s not in amendments]
+
+        return BillDocument(
+            metadata=metadata,
+            sections=main_sections,
+            amendments=amendments,
+            references=references,
+        )
+
+    def _extract_metadata(self, text: str) -> BillMetadata:
+        bill_number_match = re.search(r"(H\.R\.|S\.)\s*\d+", text)
+        title_match = re.search(r"^An?\s+Act\s+.*", text, re.MULTILINE)
+        date_match = re.search(
+            r"introduced\s+(?:on\s+)?([A-Za-z]+\s+\d{1,2},\s+\d{4})",
+            text,
+            re.IGNORECASE,
+        )
+        return BillMetadata(
+            bill_number=bill_number_match.group(0) if bill_number_match else None,
+            title=title_match.group(0) if title_match else None,
+            introduction_date=date_match.group(1) if date_match else None,
+        )
+
+    def _split_sections(self, lines: List[str]) -> List[BillSection]:
+        sections: List[BillSection] = []
+        current_title = "Intro"
+        current_text: List[str] = []
+        for line in lines:
+            if self.SECTION_PATTERN.match(line):
+                if current_text:
+                    sections.append(
+                        BillSection(title=current_title, text="\n".join(current_text))
+                    )
+                current_title = line.strip()
+                current_text = []
+                continue
+            current_text.append(line)
+        if current_text:
+            sections.append(
+                BillSection(title=current_title, text="\n".join(current_text))
+            )
+        return sections

--- a/bill_summarizer/__init__.py
+++ b/bill_summarizer/__init__.py
@@ -1,0 +1,9 @@
+"""Bill summarizer package."""
+
+from .models import SummaryResult
+from .summarizer import BillSummarizer
+
+__all__ = [
+    "SummaryResult",
+    "BillSummarizer",
+]

--- a/bill_summarizer/models.py
+++ b/bill_summarizer/models.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List
+
+@dataclass
+class SummaryResult:
+    """Holds bill summaries for different detail levels."""
+
+    executive: str
+    standard: str
+    detailed: str
+    numbers: List[str]
+    affected_parties: List[str]

--- a/bill_summarizer/summarizer.py
+++ b/bill_summarizer/summarizer.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import re
+from typing import List
+
+try:
+    from transformers import pipeline
+except Exception:  # pragma: no cover - optional dependency
+    pipeline = None
+
+try:
+    import textstat
+except Exception:  # pragma: no cover - optional dependency
+    textstat = None
+
+from bill_preprocessor.models import BillDocument
+from .models import SummaryResult
+
+
+class BillSummarizer:
+    """Generate summaries for bills at three detail levels."""
+
+    def __init__(self, model_name: str = "t5-small") -> None:
+        self.model_name = model_name
+        self._pipeline = None
+        if pipeline is not None:
+            try:
+                self._pipeline = pipeline("summarization", model=model_name)
+            except Exception:  # pragma: no cover - model download failure
+                self._pipeline = None
+
+    @staticmethod
+    def _basic_summary(text: str, sentences: int) -> str:
+        """Return the first ``sentences`` sentences from ``text``."""
+        splits = re.split(r"(?<=[.!?])\s+", text)
+        return " ".join(splits[:sentences])
+
+    def _transformers_summary(self, text: str, max_length: int) -> str:
+        if self._pipeline is None:
+            return self._basic_summary(text, 3)
+        result = self._pipeline(text, max_length=max_length, min_length=5)
+        return result[0]["summary_text"]
+
+    @staticmethod
+    def _extract_numbers(text: str) -> List[str]:
+        pattern = r"\$?\d+(?:,\d+)*(?:\.\d+)?%?"
+        return re.findall(pattern, text)
+
+    @staticmethod
+    def _identify_parties(text: str) -> List[str]:
+        parties = []
+        for term in ["citizen", "business", "agency", "government"]:
+            if term in text.lower():
+                parties.append(term)
+        return parties
+
+    def summarize(self, document: BillDocument) -> SummaryResult:
+        """Return multi-level summaries with extra information."""
+        text = "\n".join(section.text for section in document.sections)
+        executive = self._transformers_summary(text, 40)
+        standard = self._transformers_summary(text, 120)
+        detailed = self._transformers_summary(text, 250)
+        numbers = self._extract_numbers(text)
+        parties = self._identify_parties(text)
+        return SummaryResult(
+            executive=executive,
+            standard=standard,
+            detailed=detailed,
+            numbers=numbers,
+            affected_parties=parties,
+        )
+
+    @staticmethod
+    def readability(text: str) -> float:
+        """Return the Flesch-Kincaid grade level or 0 if unavailable."""
+        if textstat is None:
+            return 0.0
+        try:
+            return textstat.flesch_kincaid_grade(text)
+        except Exception:  # pragma: no cover - textstat errors
+            return 0.0

--- a/tests/test_preprocessor.py
+++ b/tests/test_preprocessor.py
@@ -1,0 +1,26 @@
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from bill_preprocessor import BillPreprocessor
+
+SAMPLE_TEXT = """\
+H.R. 1234
+An Act To Improve Something
+
+SECTION 1
+This is the first section.
+
+SECTION 2
+This is the second section.
+"""
+
+
+def test_preprocess_basic():
+    preprocessor = BillPreprocessor()
+    doc = preprocessor.preprocess(SAMPLE_TEXT)
+    assert doc.metadata.bill_number == "H.R. 1234"
+    assert len(doc.sections) == 3
+    assert doc.sections[1].title.lower().startswith("section 1")
+

--- a/tests/test_summarizer.py
+++ b/tests/test_summarizer.py
@@ -1,0 +1,29 @@
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from bill_preprocessor import BillPreprocessor
+from bill_summarizer import BillSummarizer
+
+SAMPLE_TEXT = """\
+H.R. 1234
+An Act To Improve Something
+
+SECTION 1
+This act allocates $5,000,000 for infrastructure improvements.
+Citizens shall benefit from the new funding.
+
+SECTION 2
+Businesses must comply with new regulations.
+"""
+
+
+def test_summarize_basic():
+    preprocessor = BillPreprocessor()
+    doc = preprocessor.preprocess(SAMPLE_TEXT)
+    summarizer = BillSummarizer()
+    summary = summarizer.summarize(doc)
+    assert summary.executive
+    assert "citizen" in summary.affected_parties
+    assert "$5,000,000" in summary.numbers


### PR DESCRIPTION
## Summary
- create `bill_summarizer` package with dataclasses and summarizer class
- provide simple multi-level summaries and readability scoring
- add unit test covering summarizer
- update README with summarizer features

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6854407f8d58832a9ab25ab6c6f6eb36